### PR TITLE
Bugfix: Initializing OspVariableGroupsType with empty argument caused…

### DIFF
--- a/pyOSPParser/model_description.py
+++ b/pyOSPParser/model_description.py
@@ -727,6 +727,7 @@ variable_group_types_with_variables = {
 class OspVariableGroupsType(OspGenericType):
     name = None
     Generic: List[OspGenericType] = None
+    _required_keys = []
 
     def __init__(self, dict_xml: Dict = None, **kwargs):
         super().__init__(dict_xml=dict_xml, **kwargs)
@@ -883,9 +884,10 @@ class OspModelDescription(OspModelDescriptionAbstract):
     ):
         interface_index = self.find_interface_by_name(interface_name)
         var_groups = self.VariableGroups.__getattribute__(interface_index.type_name)
-        var_groups.pop(interface_index.index)
+        deleted_var_group = var_groups.pop(interface_index.index)
         var_groups = None if len(var_groups) == 0 else var_groups
         self.VariableGroups.__setattr__(interface_index.type_name, var_groups)
+        return deleted_var_group
 
     def get_variables(self):
         osp_variables = []

--- a/pyOSPParser/system_configuration.py
+++ b/pyOSPParser/system_configuration.py
@@ -127,6 +127,23 @@ class OspInteger(Value):
     """
     value: int
     name = 'Integer'
+    _required_keys = ['value']
+
+    def __init__(self, dict_xml: Dict = None, **kwargs):
+        """Contructor for OspInteger
+
+        One should provide either 'dict_xml(dictionary)' that has a key of
+        '@value') or 'value' (integer) as a argument.
+
+        Args:
+            dict_xml(optional) {'@value': bool}
+            value(integer, optional): actual value
+        """
+        super().__init__(dict_xml=dict_xml, **kwargs)
+        value = kwargs.get('value', None)
+        if value is not None:
+            if type(value) is not int:
+                raise TypeError('The value should be of integer type.')
 
 
 class OspBoolean(Value):
@@ -136,6 +153,23 @@ class OspBoolean(Value):
     """
     value: bool
     name = 'Boolean'
+    _required_keys = ['value']
+
+    def __init__(self, dict_xml: Dict = None, **kwargs):
+        """Contructor for OspBoolean
+
+        One should provide either 'dict_xml(dictionary)' that has a key of
+        '@value') or 'value' (bool) as a argument.
+
+        Args:
+            dict_xml(optional) {'@value': bool}
+            value(bool, optional): actual value
+        """
+        super().__init__(dict_xml=dict_xml, **kwargs)
+        value = kwargs.get('value', None)
+        if value is not None:
+            if type(value) is not bool:
+                raise TypeError('The value should be of boolean type.')
 
 
 class OspString(Value):
@@ -145,15 +179,49 @@ class OspString(Value):
     """
     value: str
     name = 'String'
+    _required_keys = ['value']
+
+    def __init__(self, dict_xml: Dict = None, **kwargs):
+        """Contructor for OspString
+
+        One should provide either 'dict_xml(dictionary)' that has a key of
+        '@value') or 'value' (string) as a argument.
+
+        Args:
+            dict_xml {'@value': string}
+        """
+        super().__init__(dict_xml=dict_xml, **kwargs)
+        value = kwargs.get('value', None)
+        if value is not None:
+            if type(value) is not str:
+                raise TypeError('The value should be of string type.')
 
 
 class OspReal(Value):
     """
     The "name" member is used in other application. Please make sure that
-    the value is not changed without cross-checking
+    the value is not changed without cross-checking. One should provide 'value' argument
+    with initilaization.
     """
     value: float
     name = 'Real'
+    _required_keys = ['value']
+
+    def __init__(self, dict_xml=None, **kwargs):
+        """Contructor for OspReal
+
+        One should provide either 'dict_xml(dictionary)' that has a key of
+        '@value') or 'value' (float) as a argument.
+
+        Args:
+            dict_xml(optional) {'@value': float}
+            value(float, optional) Actual value
+        """
+        super().__init__(dict_xml=dict_xml, **kwargs)
+        value = kwargs.get('value', None)
+        if value is not None:
+            if type(value) is not float:
+                raise TypeError('The value should be of float type.')
 
 
 class OspInitialValue(OspSystemStructureAbstract):
@@ -166,15 +234,26 @@ class OspInitialValue(OspSystemStructureAbstract):
         Constructor for OspInitialValue.
 
         One should provide either 'dict_xml(dictionary)' that has a key of
-        'variable' and 'value) or 'variable (str)' and 'value (float, int, str, bool)' as
-        arguments.
+        'variable' and 'value) or 'variable (str)' and
+        'value (OspReal, OspInteger, OspString, OspBoolean)' as arguments.
 
         Args:
             variable 
             value
             dict_xml
+
+        Exceptions:
+            TypeError if the required arguments are not given
+                (either dict_xml or variable and value)
+            TypeError if you provide a wrong type for the value argument. It should be either
+                OspReal, OspInteger, OspString or OspBoolean
+
         """
         super().__init__(dict_xml=dict_xml, **kwargs)
+        if kwargs.get('value', None) is not None:
+            if type(kwargs.get('value', None)) not in [OspReal, OspInteger, OspString, OspBoolean]:
+                raise TypeError('The value should be of either OspReal, '
+                                'OspInteger, OspString or OspBoolean type')
 
     def to_dict_xml(self):
         return {

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="pyOSPParser",
-    version="0.3.0",
+    version="0.4.1",
     url="https://github.com/kevinksyTRD/pyOSPParser",
     description="A module to parse or deploy XML/JSON files for Open Simulation Platform.",
     long_description_content_type="text/markdown",

--- a/test/test_scenario.py
+++ b/test/test_scenario.py
@@ -1,6 +1,8 @@
 import random
 import string
 
+import pytest
+
 from pyOSPParser.scenario import OSPEvent, EventAction, OSPScenario
 
 
@@ -52,8 +54,13 @@ def test_event():
     assert event_dict['action'] == EventAction(action).name
     assert event_dict['value'] == value
 
+    # Test if wrong value for action causes an error
+    with pytest.raises(TypeError):
+        OSPEvent(time=time, model=model, variable=variable, action=4, value=value)
 
-def test_scenario():
+
+@pytest.fixture
+def scenario() -> OSPScenario:
     scenario_end_time = 100
     number_events = random.randint(1, 10)
     models_variables = {
@@ -72,9 +79,14 @@ def test_scenario():
         model = random.choice(list(models_variables.keys()))
         variable = random.choice(models_variables[model])
         scenario.add_event(create_an_event(model=model, variable=variable))
+    return scenario
+
+
+def test_scenario(scenario):
+    """Test Scenario for the serializing to create an XML file"""
     scenario_dict = scenario.to_dict()
 
-    assert scenario_dict['end'] == scenario_end_time
+    assert scenario_dict['end'] == scenario.end
 
     # Check if the to_dict method works properly
     for event in scenario.events:
@@ -87,3 +99,136 @@ def test_scenario():
     assert scenario_dict['description'] == scenario.description
     for event in scenario.events:
         assert event.to_dict() in scenario_dict['events']
+
+
+def test_add_duplicate_event(scenario):
+    """Test adding an event that has the same time, component name and variable name."""
+    event_duplicate: OSPEvent = random.choice(scenario.events)
+    event_to_be_added = OSPEvent(
+        time=event_duplicate.time,
+        model=event_duplicate.model,
+        variable=event_duplicate.variable,
+        action=random.choice([1, 2, 3]),
+        value=random.random()
+    )
+    with pytest.raises(TypeError):
+        scenario.add_event(event_to_be_added)
+
+
+def test_add_event_with_time_out_of_range(scenario):
+    """Test adding an event with time that is out of range."""
+    event_to_be_added = create_an_event(time=scenario.end * 1.5)
+    with pytest.raises(TypeError):
+        scenario.add_event(event_to_be_added)
+    event_to_be_added.time = -1.0
+    with pytest.raises(TypeError):
+        scenario.add_event(event_to_be_added)
+    event_to_be_added.time = random.random() * scenario.end
+    scenario.add_event(event_to_be_added)
+
+
+def test_find_event(scenario):
+    """Test finding an event for a scenario"""
+    all_model_names = [event.model for event in scenario.events]
+    all_variable_names = [event.variable for event in scenario.events]
+    all_time = [event.time for event in scenario.events]
+    all_model_names_unique = list(dict.fromkeys(all_model_names).keys())
+    all_variable_names_unique = list(dict.fromkeys(all_variable_names).keys())
+    all_time_unique = list(dict.fromkeys(all_time).keys())
+    model_name = random.choice(all_model_names_unique)
+    variable_name = random.choice(all_variable_names_unique)
+    time = random.choice(all_time_unique)
+
+    # Only with component
+    events_found = scenario.find_event(component=model_name)
+    number_counts_ref = sum(map(lambda x: x == model_name, all_model_names))
+    assert len(events_found) == number_counts_ref
+    assert all(map(lambda x: x.model == model_name, events_found))
+
+    # Only with time
+    events_found = scenario.find_event(time=time)
+    number_counts_ref = sum(map(lambda x: x == time, all_time))
+    assert len(events_found) == number_counts_ref
+    assert all(map(lambda x: x.time == time, events_found))
+
+    # Only with variable name
+    events_found = scenario.find_event(variable=variable_name)
+    number_counts_ref = sum(map(lambda x: x == variable_name, all_variable_names))
+    assert len(events_found) == number_counts_ref
+    assert all(map(lambda x: x.variable == variable_name, events_found))
+
+    # Combination
+    events_found = scenario.find_event(component=model_name, variable=variable_name)
+    number_counts_ref = sum(map(
+        lambda event: event.model == model_name and
+        event.variable == variable_name, scenario.events
+    ))
+    assert len(events_found) == number_counts_ref
+    assert all(map(
+        lambda event: event.variable == variable_name and event.model == model_name, events_found
+    ))
+
+
+def test_delete_events_all(scenario):
+    """Test deleting all events"""
+    assert len(scenario.events) > 0
+    scenario.delete_events()
+    assert len(scenario.events) == 0
+
+
+def test_delete_events_by_a_key(scenario):
+    """Test deleting events by a single key"""
+    decision = random.random()
+    if decision < 0.33:
+        key = 'time'
+    elif decision < 0.66:
+        key = 'model'
+    else:
+        key = 'variable'
+    all_with_the_key = [getattr(event, key) for event in scenario.events]
+    all_unique = list(dict.fromkeys(all_with_the_key).keys())
+    chosen = random.choice(all_unique)
+    if key == 'time':
+        scenario.delete_events(time=chosen)
+        assert len(scenario.find_event(time=chosen)) == 0
+    elif key == 'model':
+        scenario.delete_events(component=chosen)
+        assert len(scenario.find_event(component=chosen)) == 0
+    else:
+        scenario.delete_events(variable=chosen)
+        assert len(scenario.find_event(variable=chosen)) == 0
+
+
+def test_delete_event_combination(scenario):
+    """Test deleting an event by providing the key arguments"""
+    event_to_delete = random.choice(scenario.events)
+    num_events_before = len(scenario.events)
+    assert scenario.events.index(event_to_delete) >= 0
+    scenario.delete_events(
+        time=event_to_delete.time,
+        component=event_to_delete.model,
+        variable=event_to_delete.variable
+    )
+    assert len(scenario.events) == num_events_before - 1
+    with pytest.raises(ValueError):
+        scenario.events.index(event_to_delete)
+
+
+def test_update_event(scenario):
+    """Test updating an event by providing the key argument"""
+    event_to_update = random.choice(scenario.events)
+    time = event_to_update.time
+    component_name = event_to_update.model
+    variable = event_to_update.variable
+    new_action = random.randint(1, 3)
+    new_value = random.random()
+    scenario.update_event(
+        time=time,
+        component=component_name,
+        variable=variable,
+        action=new_action,
+        value=new_value
+    )
+    event = scenario.find_event(time=time, component=component_name, variable=variable)[0]
+    assert event.action == new_action
+    assert event.value == new_value

--- a/test/test_system_configuration.py
+++ b/test/test_system_configuration.py
@@ -73,6 +73,20 @@ def create_a_random_pair_of_endpoints_for_sig_conn(
         )
 
 
+def create_a_random_osp_variable_type() -> Union[OspReal, OspString, OspInteger, OspBoolean]:
+    """Create a random OspVariable such as OspReal, OspString, OspInteger, OspBoolean"""
+    variable_klass = random.choice(list(OSP_VARIABLE_CLASS.values()))
+    if variable_klass == OspReal:
+        value = random.random()
+    elif variable_klass == OspString:
+        value = create_a_random_name(5)
+    elif variable_klass == OspInteger:
+        value = random.randint(1, 10)
+    elif variable_klass == OspBoolean:
+        value = random.random() > 0.5
+    return variable_klass(value=value)
+
+
 def test_value():
     """Test Value class"""
     #: Test initialization
@@ -92,10 +106,7 @@ def test_osp_initial_value():
     # Test creating the object without any arguments
     with pytest.raises(TypeError):
         OspInitialValue()
-
-    variable_klass = random.choice(list(OSP_VARIABLE_CLASS.values()))
-    variable_obj: Union[OspReal, OspString, OspInteger, OspBoolean] = \
-        variable_klass(value=random.random())
+    variable_obj = create_a_random_osp_variable_type()
     variable = create_a_random_name(5)
     obj = OspInitialValue(variable=variable, value=variable_obj)
     assert obj.variable == variable
@@ -119,9 +130,7 @@ def test_osp_simulator():
     number_initial_values = random.randint(1, 10)
     initial_values = []
     for _ in range(number_initial_values):
-        variable_klass = random.choice(list(OSP_VARIABLE_CLASS.values()))
-        variable_obj: Union[OspReal, OspString, OspInteger, OspBoolean] = \
-            variable_klass(value=random.random())
+        variable_obj = create_a_random_osp_variable_type()
         initial_values.append(
             OspInitialValue(variable=create_a_random_name(5), value=variable_obj)
         )
@@ -548,7 +557,7 @@ def test_adding_updating_deleting_a_initial_values():
     obj = OspSystemStructure(xml_source=PATH_TO_TEST_SYSTEM_STRUCTURE)
 
     # Test failure by adding with a wrong component name
-    init_value = OspInitialValue(variable='new_variable', value=10.0)
+    init_value = OspInitialValue(variable='new_variable', value=OspReal(value=10.0))
     with pytest.raises(TypeError):
         obj.add_update_initial_value(
             component_name='This is not a correct name',
@@ -573,7 +582,10 @@ def test_adding_updating_deleting_a_initial_values():
     assert num_init_values_after == num_init_values_before + 1
 
     # Test updating the variable
-    modified_init_value = OspInitialValue(variable=init_value.variable, value=random.random() * 10)
+    modified_init_value = OspInitialValue(
+        variable=init_value.variable,
+        value=OspReal(value=random.random() * 10)
+    )
     num_init_values_before = num_init_values_after
     obj.add_update_initial_value(
         component_name=component.name,


### PR DESCRIPTION
… an error.

Modified OspModelDescription.delete_inteface() to return variable group when it's deleted
Added validation for initializing OspReal, OspInteger, OspString, OspBoolean
Fixed bugs for those class attributes of list type not being initialized properly